### PR TITLE
Improve slider

### DIFF
--- a/server.R
+++ b/server.R
@@ -13,9 +13,9 @@ shinyServer(function(input, output) {
   # slider input
   output$slider <- renderUI({
     qtlChr <- subset(qtl, chr == input$chromosome)
-    max_pos <- max(qtlChr$pos, 1)
+    max_pos <- ceiling(max(qtlChr$pos, 1))
     sliderInput("region", label = h5("Display a region of the chromosome?"),
-     min = 0, max = max_pos, value = c(0, max_pos))
+     min = 0, max = max_pos, value = c(0, max_pos), step = 1)
   })
                            
   # plots the graph


### PR DESCRIPTION
I made a couple changes that:
1. Avoid slider's initial value error
2. Clean up slider values (integers only)

The reason we were getting the error was because `max(qtlChr$pos)` was returning `-Inf` when 'All Chromosomes' was selected. I fixed this with `max(qtlChr$pos, 1)`, which allows max to be 1 if `qtlChr$pos` is undefined.
